### PR TITLE
Fix Bayesian Optimisation

### DIFF
--- a/discogen/domains/BayesianOptimisation/templates/default/edit/acq_fn.py
+++ b/discogen/domains/BayesianOptimisation/templates/default/edit/acq_fn.py
@@ -1,5 +1,5 @@
 import jax.numpy as jnp
-from typing import Any
+from typing import Any, Optional
 
 from surrogate import Surrogate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "discogen"
-version = "1.2.1"
+version = "1.2.2"
 description = "This repository contains code for the DiscoGen procedural generator for algorithm discovery tasks."
 authors = [{ name = "Alex Goldie", email = "goldie@robots.ox.ac.uk" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -768,7 +768,7 @@ wheels = [
 
 [[package]]
 name = "discogen"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Super minor bug fix

- Added `from typing import Optional` to acq_fn in BayesianOptimisation, edit function. This should have very minor impact, as any agent running on that module will likely have fixed it in step 1.